### PR TITLE
Evitando duplicações dos JARs do log4j.

### DIFF
--- a/plataoear-web/pom.xml
+++ b/plataoear-web/pom.xml
@@ -58,40 +58,21 @@
             <artifactId>jsf-api</artifactId>
         </dependency>
 
-        <!-- Log4j2 -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-                        
-        <!-- Log4j2 bridges -->
-        <!-- Log4j-->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-        </dependency>
-                        
-        <!-- Commons-logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-        </dependency>
-                        
-        <!-- slfj -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
-
         <!-- Web servlet support -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+            	<exclusion>
+            		<artifactId>log4j-api</artifactId>
+            		<groupId>org.apache.logging.log4j</groupId>
+            	</exclusion>
+            	<exclusion>
+            		<artifactId>log4j-core</artifactId>
+            		<groupId>org.apache.logging.log4j</groupId>
+            	</exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
O log4j já estava sendo declarado como dependência do módulo EJB, portanto não deveria ser colocado como dependência do módulo WEB. Ao fazer isto, as bibliotecas estavam sendo duplicadas dentro do arquivo ear, o que causa problemas. No caso da dependência "log4j-web" no módulo WEB, tem que excluir as dependências transitivas para o log4j, pelo mesmo motivo citado.
